### PR TITLE
setup.py: invalid extra_compile_args was fixed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ module1 = Extension('rle_python_interface.rle_c_wrapper',
                     libraries = ['rle_c'],
                     include_dirs = ['src'],
                     library_dirs = ['rle_python_interface'],
-                    extra_compile_args=['-D__STDC_CONSTANT_MACROS -std=c++11'],
+                    extra_compile_args=['-D__STDC_CONSTANT_MACROS', '-std=c++11'],
                     sources=['rle_python_interface/rle_c_wrapper.cpp'])
 setup(name = 'rle_python_interface',
       version='0.1.0',


### PR DESCRIPTION
I think the issue is raised on Linux only. On Linux compiler does not receive -std=c++11 option.