### PR TITLE
New isAlive flag in bust-a-move

### DIFF
--- a/src/games/supported/BustAMove.cpp
+++ b/src/games/supported/BustAMove.cpp
@@ -47,7 +47,7 @@ void BustAMoveSettings::step(const RleSystem& system) {
     m_score = playerScore;
 //    cout << "Score: " << playerScore<<endl;
 //    update terminal status
-    int isAlive = readRam(&system, 0x906);
+    int isAlive = readRam(&system, 0x994);
     if (isAlive > 0){
     	m_terminal = true;
     }


### PR DESCRIPTION
Reset only if the player loses.

With the current isAlive flag the game resets always after finishing the first round (independently if the player cleared the round or not). 

With this flag it should reset only after a defeat.